### PR TITLE
Specify ID and name in package.json

### DIFF
--- a/recipes/dev/google-voice/package.json
+++ b/recipes/dev/google-voice/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "google-voice",
+  "id": "googlevoice",
+  "name": "Google Voice",
   "version": "0.3.0",
   "description": "Google Voice",
   "main": "index.js",


### PR DESCRIPTION
I tried the current version of master in 5.0.0-beta.14, but Franz threw an error expecting an "id" in package.json. Additionally, "name" should be the way you expect to see it displayed on the Franz frontend.