### PR TITLE
Add override for user-agent

### DIFF
--- a/recipes/dev/google-voice/index.js
+++ b/recipes/dev/google-voice/index.js
@@ -2,6 +2,6 @@
 
 module.exports = Franz => class GoogleVoice extends Franz {
   overrideUserAgent() {
-    return window.navigator.userAgent.replace(/(Franz|Electron|Chrome|AppleWebKit|Safari)([^\s]+(\s|$))/g, '');
+    return window.navigator.userAgent.replace(/(Franz|Electron|Chrome|AppleWebKit|Safari)([^\s]+(\s|$))/g, '') + " Firefox/70.0";
   }
 }

--- a/recipes/dev/google-voice/index.js
+++ b/recipes/dev/google-voice/index.js
@@ -1,1 +1,7 @@
-module.exports = Franz => Franz;
+"use strict";
+
+module.exports = Franz => class GoogleVoice extends Franz {
+  overrideUserAgent() {
+    return window.navigator.userAgent.replace(/(Franz|Electron|Chrome|AppleWebKit|Safari)([^\s]+(\s|$))/g, '');
+  }
+}


### PR DESCRIPTION
Avoids "unsupported browser" error after auth by stripping additional information from the `user-agent` including (but not limited to) Electron, Franz, and Chrome.